### PR TITLE
Изменения необходимые для сборки пакета в дистрибутивы Linux

### DIFF
--- a/yaplcconnectors/YAPLC/YAPLCObject.py
+++ b/yaplcconnectors/YAPLC/YAPLCObject.py
@@ -272,6 +272,8 @@ if __name__ == "__main__":
         lib_ext = ".so"
 
     TstLib = os.path.dirname(os.path.realpath(__file__)) + "/../../../YaPySerial/bin/libYaPySerial" + lib_ext
+    if (os.name == 'posix' and not os.path.isfile(TstLib)):
+        TstLib = "libYaPySerial" + lib_ext
 
     TstRoot = TestRoot()
     print "Construct PLC..."

--- a/yaplcconnectors/YAPLC/YaPySerial.py
+++ b/yaplcconnectors/YAPLC/YaPySerial.py
@@ -147,6 +147,8 @@ if __name__ == "__main__":
         lib_ext = ".so"
 
     TestLib = os.path.dirname(os.path.realpath(__file__)) + "/../../../YaPySerial/bin/libYaPySerial" + lib_ext
+    if (os.name == 'posix' and not os.path.isfile(TestLib)):
+        TestLib = "libYaPySerial" + lib_ext
 
     TestSerial = YaPySerial( TestLib )
     TestSerial.Open( "COM256", 9600, "8N1", 2 )

--- a/yaplcconnectors/YAPLC/__init__.py
+++ b/yaplcconnectors/YAPLC/__init__.py
@@ -40,5 +40,7 @@ def YAPLC_connector_factory(uri, confnodesroot):
         lib_ext = ".so"
 
     YaPySerialLib = os.path.dirname(os.path.realpath(__file__)) + "/../../../YaPySerial/bin/libYaPySerial" + lib_ext
+    if (os.name == 'posix' and not os.path.isfile(YaPySerialLib)):
+        YaPySerialLib = "libYaPySerial" + lib_ext
 
     return YAPLCObject(YaPySerialLib,confnodesroot,comportstr)

--- a/yaplctargets/nuc242/__init__.py
+++ b/yaplctargets/nuc242/__init__.py
@@ -4,6 +4,8 @@ from yaplctargets.toolchain_yaplc_stm32 import toolchain_yaplc_stm32
 target_dir = os.path.dirname(os.path.realpath(__file__))
 base_dir = os.path.join(os.path.join(os.path.join(target_dir, ".."), ".."), "..")
 plc_rt_dir = os.path.join(os.path.join(base_dir, "RTE"), "src")
+if (os.name == 'posix' and not os.path.isfile(plc_rt_dir)):
+    plc_rt_dir = os.environ["HOME"]+"/YAPLC/RTE/src"
 
 class nuc242_target(toolchain_yaplc_stm32):
     def __init__(self, CTRInstance):

--- a/yaplctargets/nuc243/__init__.py
+++ b/yaplctargets/nuc243/__init__.py
@@ -4,6 +4,8 @@ from yaplctargets.toolchain_yaplc_stm32 import toolchain_yaplc_stm32
 target_dir = os.path.dirname(os.path.realpath(__file__))
 base_dir = os.path.join(os.path.join(os.path.join(target_dir, ".."), ".."), "..")
 plc_rt_dir = os.path.join(os.path.join(base_dir, "RTE"), "src")
+if (os.name == 'posix' and not os.path.isfile(plc_rt_dir)):
+    plc_rt_dir = os.environ["HOME"]+"/YAPLC/RTE/src"
 
 class nuc243_target(toolchain_yaplc_stm32):
     def __init__(self, CTRInstance):

--- a/yaplctargets/nuc247/__init__.py
+++ b/yaplctargets/nuc247/__init__.py
@@ -4,6 +4,8 @@ from yaplctargets.toolchain_yaplc_stm32 import toolchain_yaplc_stm32
 target_dir = os.path.dirname(os.path.realpath(__file__))
 base_dir = os.path.join(os.path.join(os.path.join(target_dir, ".."), ".."), "..")
 plc_rt_dir = os.path.join(os.path.join(base_dir, "RTE"), "src")
+if (os.name == 'posix' and not os.path.isfile(plc_rt_dir)):
+    plc_rt_dir = os.environ["HOME"]+"/YAPLC/RTE/src"
 
 class nuc247_target(toolchain_yaplc_stm32):
     def __init__(self, CTRInstance):

--- a/yaplctargets/nuc251/__init__.py
+++ b/yaplctargets/nuc251/__init__.py
@@ -4,6 +4,8 @@ from yaplctargets.toolchain_yaplc_stm32 import toolchain_yaplc_stm32
 target_dir = os.path.dirname(os.path.realpath(__file__))
 base_dir = os.path.join(os.path.join(os.path.join(target_dir, ".."), ".."), "..")
 plc_rt_dir = os.path.join(os.path.join(base_dir, "RTE"), "src")
+if (os.name == 'posix' and not os.path.isfile(plc_rt_dir)):
+    plc_rt_dir = os.environ["HOME"]+"/YAPLC/RTE/src"
 
 class nuc251_target(toolchain_yaplc_stm32):
     def __init__(self, CTRInstance):

--- a/yaplctargets/toolchain_yaplc.py
+++ b/yaplctargets/toolchain_yaplc.py
@@ -5,6 +5,8 @@ from targets.toolchain_gcc import toolchain_gcc
 toolchain_dir  = os.path.dirname(os.path.realpath(__file__))
 base_dir       = os.path.join(os.path.join(toolchain_dir, ".."), "..")
 runtime_dir    = os.path.join(os.path.join(base_dir, "RTE"), "src")
+if (os.name == 'posix' and not os.path.isfile(runtime_dir)):
+    runtime_dir = os.environ["HOME"]+"/YAPLC/RTE/src"
 
 class toolchain_yaplc(toolchain_gcc):
     def __init__(self, CTRInstance):

--- a/yaplctargets/toolchain_yaplc_stm32.py
+++ b/yaplctargets/toolchain_yaplc_stm32.py
@@ -9,6 +9,8 @@ class toolchain_yaplc_stm32(toolchain_yaplc):
     def GetBinaryCode(self):
         if os.path.exists(self.exe_path):
             yaplc_boot_loader = os.path.join(os.path.join(base_dir, "stm32flash"), "stm32flash")
+            if (os.name == 'posix' and not os.path.isfile(yaplc_boot_loader)):
+                yaplc_boot_loader = "stm32flash"
             command = [yaplc_boot_loader, "-w", self.exe_path + ".hex", "-v", "-g", "0x0", "-S", self.load_addr, "%(serial_port)s"]
             return command
         else:

--- a/yaplctargets/yaplc/__init__.py
+++ b/yaplctargets/yaplc/__init__.py
@@ -4,6 +4,8 @@ from yaplctargets.toolchain_yaplc_stm32 import toolchain_yaplc_stm32
 target_dir = os.path.dirname(os.path.realpath(__file__))
 base_dir = os.path.join(os.path.join(os.path.join(target_dir, ".."), ".."), "..")
 plc_rt_dir = os.path.join(os.path.join(base_dir, "RTE"), "src")
+if (os.name == 'posix' and not os.path.isfile(plc_rt_dir)):
+    plc_rt_dir = os.environ["HOME"]+"/YAPLC/RTE/src"
 
 class yaplc_target(toolchain_yaplc_stm32):
     def __init__(self, CTRInstance):


### PR DESCRIPTION
Здравствуйте!
Для того, чтобы собрать пакет для дистрибутива Linux (я собираю пакет для ALT Linux), нужно внести следующие изменения в код:

1. Использовать системный matiec, т.е. находящийся в /usr/bin/iec2c и библиотеки в /usr/lib/matiec/ Если они установлены, естественно.
Создал issue в репозитории skvorl/beremiz: https://bitbucket.org/skvorl/beremiz/issues/29/used-system-matiec
Пакет matiec для ALT Linux собрал.

2. Использовать системную библиотеку yapyserial, находящуюся либо в /usr/lib/libYaPySerial.so для 32 битной системы, либо /usr/lib64/libYaPySerial.so для 64 битной системы.

3. Использовать системный /usr/bin/stm32flash

4. RTE и необходимые для сборки прошивок исходники в Linux, думаю, хранить в $HOME/YAPLC
В связи с этим нужно, чтобы путь до директории $HOME/YAPLC/RTE пользовался приоритетом.